### PR TITLE
[feature/chatting]Fix: access  토큰 재발급 오류

### DIFF
--- a/src/api/get_new_access.tsx
+++ b/src/api/get_new_access.tsx
@@ -1,20 +1,26 @@
+import { useLoadingStore } from "../../store/loading_store";
 import instance from "./axios";
 
 export const getNewAccessToken = async () => {
+  const { setIsLoading } = useLoadingStore.getState(); // 상태 가져오기
   try {
     const response = await instance.post("users/token-refresh/", {
       refresh: localStorage.getItem("refresh"),
     });
     const newAccessToken = response.data.access;
     localStorage.setItem("access", newAccessToken);
+    setIsLoading(false);
     return newAccessToken;
   } catch (error) {
     console.error("Refresh token error:", error);
+    await instance.post("users/sign-out/", {
+      refresh: localStorage.getItem("refresh"),
+    });
     localStorage.removeItem("access");
     localStorage.removeItem("refresh");
     localStorage.removeItem("id");
     localStorage.removeItem("nickname");
-    // alert("토큰 삭제합니다.");
+    alert("토큰 삭제합니다.");
     throw error;
   }
 };


### PR DESCRIPTION
access토큰 재발급 요청이 무한으로 가는 증상.
interceptor와 get_new_accessToken 함수가 둘다 비동기여서,
동기적으로 실행할 수 있게 401이 뜨자마자 access를 remove함